### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ slack = new Slack('https://<incoming-hook-url>',{
 });
 ```
 
-###Send message:
+### Send message:
 
 If channel is not set default channel is *#general*
 ```js
@@ -40,7 +40,7 @@ slack.notify("Message", function(err, result){
 
 ```
 
-###Customized Appearance:
+### Customized Appearance:
 
 You can customize the name and icon of your Incoming Webhook.
 
@@ -66,7 +66,7 @@ slack.notify(messages);
 ```
 
 
-###Message Attachments:
+### Message Attachments:
 To display a richly-formatted message attachment in Slack, you can use the same JSON payload as above, but add in an attachments array. Each element of this array is a hash containing the following parameters:
 
 ```js
@@ -99,7 +99,7 @@ slack.notify(messages, function(err, result) {
 
 ```
 
-###Documentation
+### Documentation
 
 For more information such as send URL link, Message Formatting, @mention and Parsing modes,  please follow the link below
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
